### PR TITLE
Update to 21.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,14 +16,21 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
 
 test:
   imports:
     - incremental
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/hawkowl/incremental
@@ -32,6 +39,7 @@ about:
   license_file: LICENSE
   summary: Incremental is a small library that versions your Python projects.
   dev_url: https://github.com/hawkowl/incremental
+  doc_url: https://github.com/twisted/incremental/blob/trunk/README.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update incremental to 21.3.0
It's a dependency of `twisted 21.3.0` whch requires by `prometheus_client 0.12.0`

Bug Tracker: new open issues https://github.com/hawkowl/incremental/issues
Github releases:  https://github.com/hawkowl/incremental/releases
Upstream license:  License file:  https://github.com/hawkowl/incremental/blob/master/LICENSE
Upstream setup file: https://github.com/twisted/incremental/blob/incremental-21.3.0/setup.py

The package incremental is mentioned inside the packages:
twisted |

Actions:
1. Add missing packages: setuptools, wheel
2. Fix python
3. Add `pip check`
4. Add doc_url

Result:
- all-succeeded
